### PR TITLE
feat: Make id optional in the item and generate it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1618,6 +1618,12 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
+    },
     "@types/ws": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
@@ -7449,6 +7455,11 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -8274,9 +8285,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.11",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.5.0",
     "@typescript-eslint/parser": "^5.5.0",
     "eslint": "^8.3.0",
@@ -56,6 +57,7 @@
     "dcl-crypto": "^2.3.0",
     "ethers": "^5.5.2",
     "form-data": "^4.0.0",
-    "jszip": "^3.7.1"
+    "jszip": "^3.7.1",
+    "uuid": "^8.3.2"
   }
 }

--- a/src/files/schemas.ts
+++ b/src/files/schemas.ts
@@ -48,6 +48,6 @@ export const AssetJSONSchema = {
     tags: { type: 'array', items: { type: 'string' } },
     representations: { type: 'array', items: WearableRepresentationSchema }
   },
-  required: ['id', 'name', 'rarity', 'category', 'representations'],
+  required: ['name', 'rarity', 'category', 'representations'],
   additionalProperties: false
 }

--- a/src/item/ItemFactory.spec.ts
+++ b/src/item/ItemFactory.spec.ts
@@ -1,11 +1,13 @@
 import { Rarity, WearableRepresentation } from '@dcl/schemas'
 import { prefixContentName } from '../content/content'
+import { Content } from '../content/types'
 import { AssetJSON } from '../files/types'
 import { toCamelCase } from '../test-utils/string'
 import { THUMBNAIL_PATH } from './constants'
 import { ItemFactory } from './ItemFactory'
 import {
   BodyShapeType,
+  BuiltItem,
   ItemType,
   LocalItem,
   ModelMetrics,
@@ -89,7 +91,7 @@ const testDataPropertyBuilder = <T extends keyof LocalItem['data']>(
         createBasicItem(factory)
       })
 
-      it('should build an item with the updated id', () => {
+      it(`should build an item with the updated ${property}`, () => {
         factory[`with${camelCasedProperty}`](value)
         return expect(factory.build()).resolves.toEqual(
           expect.objectContaining({
@@ -929,6 +931,33 @@ describe('when creating a new item from an asset object', () => {
         [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH]
       }
     })
+  })
+})
+
+describe('when building a new item and the id property is not specified', () => {
+  let builtItem: BuiltItem<Content>
+
+  beforeEach(async () => {
+    builtItem = await new ItemFactory()
+      .newItem({
+        name: 'aName',
+        rarity: Rarity.COMMON,
+        category: WearableCategory.EYEBROWS,
+        collection_id: 'aCollectionId',
+        description: 'aDescription',
+        urn: null
+      })
+      .build()
+  })
+
+  it('should generate a new uuid for the item', () => {
+    expect(builtItem.item).toEqual(
+      expect.objectContaining({
+        id: expect.stringMatching(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+        )
+      })
+    )
   })
 })
 

--- a/src/item/ItemFactory.ts
+++ b/src/item/ItemFactory.ts
@@ -1,4 +1,5 @@
 import { Rarity, WearableRepresentation } from '@dcl/schemas'
+import { v4 as uuidV4 } from 'uuid'
 import {
   computeHashes,
   prefixContentName,
@@ -45,7 +46,7 @@ export class ItemFactory<X extends Content> {
     }
 
     this.item = {
-      id,
+      id: id ?? uuidV4(),
       name,
       description: description || '',
       thumbnail: THUMBNAIL_PATH,

--- a/src/item/types.ts
+++ b/src/item/types.ts
@@ -40,8 +40,8 @@ export type LocalItem = Omit<
   | 'beneficiary'
 >
 
-export type BasicItem = Pick<LocalItem, 'id' | 'name' | 'rarity'> &
-  Partial<Pick<LocalItem, 'description' | 'collection_id' | 'urn'>> &
+export type BasicItem = Pick<LocalItem, 'name' | 'rarity'> &
+  Partial<Pick<LocalItem, 'description' | 'collection_id' | 'urn' | 'id'>> &
   Pick<WearableData, 'category'>
 
 export enum ItemType {


### PR DESCRIPTION
This PR makes the id property when building the item in the `ItemFactory` optional so it can generate it if it was not provided.