### PR TITLE
feat: Add support for array buffers, node buffers and auto-selecting file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Install Size](https://packagephobia.now.sh/badge?p=@dcl/builder-client@latest)](https://packagephobia.now.sh/result?p=@dcl/builder-client@latest)
 [![Coverage Status](https://coveralls.io/repos/github/decentraland/builder-client/badge.svg?branch=main)](https://coveralls.io/github/decentraland/builder-client?branch=main)
 
+
 ## Using the Builder client
 
 Using the builder client requires an `AuthIdentity` to be created.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Install Size](https://packagephobia.now.sh/badge?p=@dcl/builder-client@latest)](https://packagephobia.now.sh/result?p=@dcl/builder-client@latest)
 [![Coverage Status](https://coveralls.io/repos/github/decentraland/builder-client/badge.svg?branch=main)](https://coveralls.io/github/decentraland/builder-client?branch=main)
 
-
 ## Using the Builder client
 
 Using the builder client requires an `AuthIdentity` to be created.

--- a/src/client/BuilderClient.ts
+++ b/src/client/BuilderClient.ts
@@ -57,7 +57,7 @@ export class BuilderClient {
     return headers
   }
 
-  private convertToFormDataBuffer(data: Content): Blob | Buffer {
+  private convertToFormDataBinary(data: Content): Blob | Buffer {
     const blobExists = globalThis.Blob !== undefined
     const bufferExists = Buffer !== undefined
     if (
@@ -126,7 +126,7 @@ export class BuilderClient {
       for (const path in newContent) {
         formData.append(
           item.contents[path],
-          this.convertToFormDataBuffer(newContent[path])
+          this.convertToFormDataBinary(newContent[path])
         )
       }
 

--- a/src/client/BuilderClient.ts
+++ b/src/client/BuilderClient.ts
@@ -1,8 +1,8 @@
 import FormData from 'form-data'
 import crossFetch from 'cross-fetch'
 import { Authenticator, AuthIdentity } from 'dcl-crypto'
-import { Content } from '../content/types'
 import { RemoteItem, LocalItem } from '../item/types'
+import { Content } from '../content/types'
 import { ClientError } from './BuilderClient.errors'
 import { ServerResponse } from './types'
 
@@ -99,6 +99,13 @@ export class BuilderClient {
     if (Object.keys(newContent).length > 0) {
       const formData = new FormData()
       for (const path in newContent) {
+        if (newContent[path] instanceof Uint8Array) {
+          formData.append(
+            item.contents[path],
+            (newContent[path] as Uint8Array).buffer
+          )
+        }
+
         formData.append(item.contents[path], newContent[path])
       }
 

--- a/src/content/content.spec.ts
+++ b/src/content/content.spec.ts
@@ -1,25 +1,49 @@
+import { TextEncoder } from 'util'
 import { THUMBNAIL_PATH } from '../item/constants'
 import { BodyShapeType } from '../item/types'
 import { computeHashes, prefixContentName, sortContent } from './content'
 import { RawContent } from './types'
 
 describe('when computing the hashes of raw content', () => {
-  let content: RawContent<Uint8Array>
+  let content: RawContent<Uint8Array | ArrayBuffer>
   let hashes: Record<string, string>
+  let expectedHashes: Record<string, string>
+  let encoder: TextEncoder
 
-  beforeEach(async () => {
-    content = {
-      someThing: Buffer.from('aThing'),
-      someOtherThing: Buffer.from('someOtherThing')
-    }
-    hashes = await computeHashes(content)
-  })
-
-  it('should compute the hash of each Uint8Array', () => {
-    expect(hashes).toEqual({
+  beforeEach(() => {
+    encoder = new TextEncoder()
+    expectedHashes = {
       someOtherThing:
         'bafkreiatcrqxiuonjtnt2pml2kmfpct6veomwajfiz5x3t2icj22rpt5ly',
       someThing: 'bafkreig6f2q62jrqswtg4to2yr454aa2amhuevgsyl6oj3qrwshlazufcu'
+    }
+  })
+
+  describe('when the content is in the Uint8Array format', () => {
+    beforeEach(async () => {
+      content = {
+        someThing: encoder.encode('aThing'),
+        someOtherThing: encoder.encode('someOtherThing')
+      }
+      hashes = await computeHashes(content)
+    })
+
+    it('should compute the hash of each Uint8Array', () => {
+      expect(hashes).toEqual(expectedHashes)
+    })
+  })
+
+  describe('when the content is in the ArrayBuffer format', () => {
+    beforeEach(async () => {
+      content = {
+        someThing: encoder.encode('aThing').buffer,
+        someOtherThing: encoder.encode('someOtherThing').buffer
+      }
+      hashes = await computeHashes(content)
+    })
+
+    it('should compute the hash of each ArrayBuffer', () => {
+      expect(hashes).toEqual(expectedHashes)
     })
   })
 })

--- a/src/content/content.spec.ts
+++ b/src/content/content.spec.ts
@@ -46,6 +46,20 @@ describe('when computing the hashes of raw content', () => {
       expect(hashes).toEqual(expectedHashes)
     })
   })
+
+  describe('when the content is in the Buffer format', () => {
+    beforeEach(async () => {
+      content = {
+        someThing: Buffer.from('aThing'),
+        someOtherThing: Buffer.from('someOtherThing')
+      }
+      hashes = await computeHashes(content)
+    })
+
+    it('should compute the hash of each Buffer', () => {
+      expect(hashes).toEqual(expectedHashes)
+    })
+  })
 })
 
 describe('when prefixing the content name', () => {

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,4 +1,5 @@
 import { Hashing } from 'dcl-catalyst-commons'
+import { Buffer } from 'buffer'
 import { BodyShapeType } from '../item/types'
 import { THUMBNAIL_PATH } from '../item/constants'
 import { Content, HashedContent, RawContent, SortedContent } from './types'
@@ -32,7 +33,7 @@ export async function computeHashes<T extends Content>(
  */
 async function makeContentFile(
   path: string,
-  content: string | Uint8Array | Blob | ArrayBuffer
+  content: string | Uint8Array | Blob | ArrayBuffer | Buffer
 ): Promise<{ name: string; content: Uint8Array }> {
   if (typeof content === 'string') {
     // This must be polyfilled in the browser
@@ -45,6 +46,8 @@ async function makeContentFile(
   } else if (content instanceof Uint8Array) {
     return { name: path, content }
   } else if (content instanceof ArrayBuffer) {
+    return { name: path, content: new Uint8Array(content) }
+  } else if (Buffer.isBuffer(content)) {
     return { name: path, content: new Uint8Array(content) }
   }
   throw new Error(

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -32,7 +32,7 @@ export async function computeHashes<T extends Content>(
  */
 async function makeContentFile(
   path: string,
-  content: string | Uint8Array | Blob
+  content: string | Uint8Array | Blob | ArrayBuffer
 ): Promise<{ name: string; content: Uint8Array }> {
   if (typeof content === 'string') {
     // This must be polyfilled in the browser
@@ -44,6 +44,8 @@ async function makeContentFile(
     return { name: path, content: new Uint8Array(buffer) }
   } else if (content instanceof Uint8Array) {
     return { name: path, content }
+  } else if (content instanceof ArrayBuffer) {
+    return { name: path, content: new Uint8Array(content) }
   }
   throw new Error(
     'Unable to create ContentFile: content must be a string, a Blob or a Uint8Array'
@@ -69,7 +71,7 @@ export function prefixContentName(
  * @param bodyShape - The body shaped used to sort the content.
  * @param contents - The contents to be sorted.
  */
-export function sortContent<T extends Blob | Uint8Array>(
+export function sortContent<T extends Content>(
   bodyShape: BodyShapeType,
   contents: RawContent<T>
 ): SortedContent<T> {

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -1,4 +1,4 @@
-export type Content = Uint8Array | Blob | ArrayBuffer
+export type Content = Uint8Array | Blob | ArrayBuffer | Buffer
 
 export type SortedContent<T extends Content> = {
   male: Record<string, T>

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -1,4 +1,4 @@
-export type Content = Uint8Array | Blob
+export type Content = Uint8Array | Blob | ArrayBuffer
 
 export type SortedContent<T extends Content> = {
   male: Record<string, T>

--- a/src/files/files.spec.ts
+++ b/src/files/files.spec.ts
@@ -210,6 +210,25 @@ describe('when loading an item file', () => {
             })
           })
         })
+
+        describe('and the zip file is in the Buffer format', () => {
+          beforeEach(async () => {
+            zipFileContent = await zipFile.generateAsync({
+              type: 'nodebuffer'
+            })
+          })
+
+          it('should build the LoadedFile with the zipped contents and the asset file with the same buffer format as the zip', () => {
+            return expect(loadFile(fileName, zipFileContent)).resolves.toEqual({
+              content: {
+                [modelFile]: Buffer.from(modelFileContent.buffer),
+                [textureFile]: Buffer.from(textureFileContent.buffer),
+                [THUMBNAIL_PATH]: Buffer.from(thumbnailContent.buffer)
+              },
+              asset: assetFileContent
+            })
+          })
+        })
       })
     })
 

--- a/src/files/files.ts
+++ b/src/files/files.ts
@@ -75,13 +75,14 @@ async function handleZippedModelFiles<T extends Content>(
 
   const fileNames: string[] = []
   const promiseOfFileContents: Array<Promise<T>> = []
-
   let fileFormat: OutputType
   if (globalThis.Blob && zipFile instanceof globalThis.Blob) {
     fileFormat = 'blob'
+  } else if (Buffer.isBuffer(zipFile)) {
+    fileFormat = 'nodebuffer'
   } else if (zipFile instanceof Uint8Array) {
     fileFormat = 'uint8array'
-  } else {
+  } else if (zipFile instanceof ArrayBuffer) {
     fileFormat = 'arraybuffer'
   }
 


### PR DESCRIPTION
This PR adds:
- Support for array buffers and specially Node buffers that are needed to send binary formatted multipart data.
- Support for auto-selecting the output format of the files that are loaded using the `loadFiles` function.
- Support for the Uint8Array and ArrayBuffers for the files upload procedure when upserting a file.