### PR TITLE
feat: Add the local_content_hash property to the remote item type

### DIFF
--- a/src/client/BuilderClient.spec.ts
+++ b/src/client/BuilderClient.spec.ts
@@ -104,7 +104,8 @@ beforeEach(async () => {
     price: null,
     eth_address: '0x00',
     beneficiary: null,
-    total_supply: 1000
+    total_supply: 1000,
+    local_content_hash: 'someHash'
   }
 })
 

--- a/src/item/types.ts
+++ b/src/item/types.ts
@@ -19,6 +19,7 @@ export type RemoteItem = {
   metrics: ModelMetrics
   contents: Record<string, string>
   content_hash: string | null
+  local_content_hash: string | null
   is_published: boolean
   is_approved: boolean
   in_catalyst: boolean
@@ -38,6 +39,7 @@ export type LocalItem = Omit<
   | 'eth_address'
   | 'price'
   | 'beneficiary'
+  | 'local_content_hash'
 >
 
 export type BasicItem = Pick<LocalItem, 'name' | 'rarity'> &


### PR DESCRIPTION
This PR adds the `local_content_hash` property that will be returned when inserting or updating an item.