### PR TITLE
feat: Add method to add catalyst image

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,20 +80,19 @@ Representations can be added using the `withRepresentation`: or `withoutRepresen
 
 ```typescript
 const itemFactory = new ItemFactory(oldItem)
-itemFactory
-  .withRepresentation(
-      bodyShape: BodyShapeType.MALE,
-      model: 'a_model.glb',
-      contents: { 'a_model.glb': modelContent, [THUMBNAIL_PATH]: thumbnailContent },
-      metrics: {
-        triangles: 106,
-        materials: 107,
-        meshes: 108,
-        bodies: 109,
-        entities: 110,
-        textures: 111
-      }
-  })
+itemFactory.withRepresentation(
+  BodyShapeType.MALE,
+  'a_model.glb',
+  { 'a_model.glb': modelContent, [THUMBNAIL_PATH]: thumbnailContent },
+  {
+    triangles: 106,
+    materials: 107,
+    meshes: 108,
+    bodies: 109,
+    entities: 110,
+    textures: 111
+  }
+)
 ```
 
 or deleted from the item using the `withoutRepresentation` method:
@@ -134,12 +133,12 @@ itemFactory.newItem({
   collection_id: 'aCollectionId',
   description: 'aDescription'
 }).withRepresentation(
-    bodyShape: BodyShapeType.MALE,
+    BodyShapeType.MALE,
     // Uses the main model from the loadedItem variable
-    model: loadedItem.mainModel,
+    loadedItem.mainModel,
     // Uses the content from the loadedItem variable
-    contents: loadedItem.content,
-    metrics: {
+    loadedItem.content,
+    {
       triangles: 106,
       materials: 107,
       meshes: 108,
@@ -147,7 +146,7 @@ itemFactory.newItem({
       entities: 110,
       textures: 111
     }
-  })
+  )
 ```
 
 For the 3rd case, the function will create a `LoadedItem` object that will contain the item's contents as `RawContent`, and it will also contain the asset property
@@ -229,10 +228,10 @@ const builtItem = await itemFactory
   .withCollectionId('aCollectionId')
   .withDescription('aDescription')
   .withRepresentation(
-    bodyShape: BodyShapeType.MALE,
-    model: 'a_model.glb',
-    contents: { 'a_model.glb': modelContent, [THUMBNAIL_PATH]: thumbnailContent },
-    metrics: {
+    BodyShapeType.MALE,
+    'a_model.glb',
+    { 'a_model.glb': modelContent, [THUMBNAIL_PATH]: thumbnailContent },
+    {
       triangles: 106,
       materials: 107,
       meshes: 108,
@@ -240,7 +239,7 @@ const builtItem = await itemFactory
       entities: 110,
       textures: 111
     }
-  })
+  )
   .build()
 await client.upsertItem(builtItem.item, builtItem.newContent)
 ```

--- a/src/item/ItemFactory.spec.ts
+++ b/src/item/ItemFactory.spec.ts
@@ -3,7 +3,7 @@ import { prefixContentName } from '../content/content'
 import { Content } from '../content/types'
 import { AssetJSON } from '../files/types'
 import { toCamelCase } from '../test-utils/string'
-import { THUMBNAIL_PATH } from './constants'
+import { IMAGE_PATH, THUMBNAIL_PATH } from './constants'
 import { ItemFactory } from './ItemFactory'
 import {
   BodyShapeType,
@@ -860,6 +860,89 @@ describe("when setting the item's thumbnail", () => {
           expect.objectContaining({
             newContent: expect.objectContaining({
               [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH]
+            })
+          })
+        )
+      })
+    })
+  })
+})
+
+describe("when setting the item's image", () => {
+  let newImage: Uint8Array
+
+  beforeEach(() => {
+    newImage = new Uint8Array([11, 12, 13])
+  })
+
+  describe('and the item was not initialized', () => {
+    it('should throw an error signaling that the item has not been initialized', () => {
+      expect(() =>
+        itemFactory.withoutRepresentation(BodyShapeType.MALE)
+      ).toThrow('Item has not been initialized')
+    })
+  })
+
+  describe('and the item is already initialized', () => {
+    beforeEach(() => {
+      createBasicItem(itemFactory)
+    })
+
+    describe('and the item already contained a image', () => {
+      let newImageHash: string
+
+      beforeEach(() => {
+        newImageHash =
+          'bafkreigj4dzk52sis4yszi77peaijhoo5pmbvdww33byqkku62u2apv5e4'
+        itemFactory.withImage(newImage)
+      })
+
+      it('should have set the new image in the contents', () => {
+        return expect(itemFactory.build()).resolves.toEqual(
+          expect.objectContaining({
+            item: expect.objectContaining({
+              contents: expect.objectContaining({
+                [IMAGE_PATH]: newImageHash
+              })
+            })
+          })
+        )
+      })
+
+      it('should have set the new image in the new contents', () => {
+        return expect(itemFactory.build()).resolves.toEqual(
+          expect.objectContaining({
+            newContent: expect.objectContaining({
+              [IMAGE_PATH]: newImage
+            })
+          })
+        )
+      })
+    })
+
+    describe("and the item didn't contain a image", () => {
+      beforeEach(() => {
+        itemFactory.withImage(newImage)
+      })
+
+      it('should have set the new image in the contents', () => {
+        return expect(itemFactory.build()).resolves.toEqual(
+          expect.objectContaining({
+            item: expect.objectContaining({
+              contents: expect.objectContaining({
+                [IMAGE_PATH]:
+                  'bafkreigj4dzk52sis4yszi77peaijhoo5pmbvdww33byqkku62u2apv5e4'
+              })
+            })
+          })
+        )
+      })
+
+      it('should have set the new image in the new contents', () => {
+        return expect(itemFactory.build()).resolves.toEqual(
+          expect.objectContaining({
+            newContent: expect.objectContaining({
+              [IMAGE_PATH]: newImage
             })
           })
         )

--- a/src/item/ItemFactory.ts
+++ b/src/item/ItemFactory.ts
@@ -7,7 +7,7 @@ import {
 } from '../content/content'
 import { Content, RawContent, SortedContent } from '../content/types'
 import { AssetJSON } from '../files/types'
-import { DEFAULT_METRICS, THUMBNAIL_PATH } from './constants'
+import { DEFAULT_METRICS, IMAGE_PATH, THUMBNAIL_PATH } from './constants'
 import { ItemNotInitializedError } from './ItemFactory.errors'
 import {
   BasicItem,
@@ -219,6 +219,27 @@ export class ItemFactory<X extends Content> {
       [THUMBNAIL_PATH]: thumbnail
     }
     delete this.item.contents[THUMBNAIL_PATH]
+
+    return this
+  }
+
+  /**
+   * Sets or updates the item's image.
+   * The image will be used at the deployment process
+   * to be uploaded to the catalyst.
+   * It requires the item to be defined first.
+   * @param thumbnail - The item's thumbnail.
+   */
+  public withImage(image: X): ItemFactory<X> {
+    if (!this.item) {
+      throw new ItemNotInitializedError()
+    }
+
+    this.newContent = {
+      ...this.newContent,
+      [IMAGE_PATH]: image
+    }
+    delete this.item.contents[IMAGE_PATH]
 
     return this
   }

--- a/src/item/constants.ts
+++ b/src/item/constants.ts
@@ -1,4 +1,5 @@
 export const THUMBNAIL_PATH = 'thumbnail.png'
+export const IMAGE_PATH = 'image.png'
 export const DEFAULT_METRICS = {
   triangles: 0,
   materials: 0,


### PR DESCRIPTION
This PR adds a mechanism to add the catalyst image when uploading the item to the builder server.