### PR TITLE
feat: withContents and form data generation

### DIFF
--- a/src/client/BuilderClient.ts
+++ b/src/client/BuilderClient.ts
@@ -132,7 +132,8 @@ export class BuilderClient {
       for (const path in newContent) {
         formData.append(
           item.contents[path],
-          this.convertToFormDataBinary(newContent[path])
+          this.convertToFormDataBinary(newContent[path]),
+          path
         )
       }
 
@@ -153,7 +154,7 @@ export class BuilderClient {
       if (!uploadResponse.ok || !uploadResponseBody.ok) {
         throw new ClientError(
           uploadResponseBody.error ?? 'Unknown error',
-          upsertResponse.status,
+          uploadResponse.status,
           uploadResponseBody.data
         )
       }

--- a/src/item/ItemFactory.spec.ts
+++ b/src/item/ItemFactory.spec.ts
@@ -868,6 +868,63 @@ describe("when setting the item's thumbnail", () => {
   })
 })
 
+describe("when setting the item's contents", () => {
+  beforeEach(() => {
+    newContent = {
+      'some key': new Uint8Array([1, 2, 3]),
+      'some other key': new Uint8Array([11, 12, 13])
+    }
+  })
+
+  describe('and the item was not initialized', () => {
+    it('should throw an error signaling that the item has not been initialized', () => {
+      expect(() => itemFactory.withContent(newContent)).toThrow(
+        'Item has not been initialized'
+      )
+    })
+  })
+
+  describe('and the item is already initialized', () => {
+    beforeEach(() => {
+      createBasicItem(itemFactory)
+    })
+
+    describe('and the item already contained contents', () => {
+      beforeEach(() => {
+        itemFactory
+          .withRepresentation(BodyShapeType.MALE, modelPath, contents, metrics)
+          .withContent(newContent)
+      })
+
+      it('should have merged the original contents with the new one', () => {
+        return expect(itemFactory.build()).resolves.toEqual(
+          expect.objectContaining({
+            newContent: {
+              [prefixedMaleModel]: contents[modelPath],
+              [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH],
+              ...newContent
+            }
+          })
+        )
+      })
+    })
+
+    describe("and the item didn't contain a image", () => {
+      beforeEach(() => {
+        itemFactory.withContent(newContent)
+      })
+
+      it('should have set the new image in the contents', () => {
+        return expect(itemFactory.build()).resolves.toEqual(
+          expect.objectContaining({
+            newContent
+          })
+        )
+      })
+    })
+  })
+})
+
 describe("when setting the item's image", () => {
   let newImage: Uint8Array
 
@@ -877,9 +934,9 @@ describe("when setting the item's image", () => {
 
   describe('and the item was not initialized', () => {
     it('should throw an error signaling that the item has not been initialized', () => {
-      expect(() =>
-        itemFactory.withoutRepresentation(BodyShapeType.MALE)
-      ).toThrow('Item has not been initialized')
+      expect(() => itemFactory.withImage(newImage)).toThrow(
+        'Item has not been initialized'
+      )
     })
   })
 

--- a/src/item/ItemFactory.ts
+++ b/src/item/ItemFactory.ts
@@ -224,6 +224,27 @@ export class ItemFactory<X extends Content> {
   }
 
   /**
+   * Sets or updates the item's contents.
+   * It requires the item to be defined first.
+   * @param contents - The item's new contents
+   */
+  public withContent(content: Record<string, X>): ItemFactory<X> {
+    if (!this.item) {
+      throw new ItemNotInitializedError()
+    }
+
+    this.newContent = {
+      ...this.newContent,
+      ...content
+    }
+    for (const key in content) {
+      delete this.item.contents[key]
+    }
+
+    return this
+  }
+
+  /**
    * Sets or updates the item's image.
    * The image will be used at the deployment process
    * to be uploaded to the catalyst.


### PR DESCRIPTION
Adds the `withContent` method and fixes sending data via a FormData to the builder server