### PR TITLE
feat: Add method to get a third party

### DIFF
--- a/src/client/BuilderClient.spec.ts
+++ b/src/client/BuilderClient.spec.ts
@@ -798,7 +798,7 @@ describe('when getting a third party', () => {
 
     it('should throw a client error with the error in the body', async () => {
       await expect(client.getThirdParty(thirdPartyId)).rejects.toEqual(
-        new ClientError(response.error!, 200, response.data)
+        new ClientError(response.error as string, 200, response.data)
       )
     })
   })

--- a/src/client/BuilderClient.spec.ts
+++ b/src/client/BuilderClient.spec.ts
@@ -16,7 +16,13 @@ import {
   publicKeyRegex,
   secondHeaderPayloadRegex
 } from './matchers'
-import { GetNFTParams, GetNFTsResponse, NFT, ServerResponse } from './types'
+import {
+  GetNFTParams,
+  GetNFTsResponse,
+  NFT,
+  ServerResponse,
+  ThirdParty
+} from './types'
 
 nock.disableNetConnect()
 
@@ -740,6 +746,85 @@ describe('when getting a single nft', () => {
           new ClientError(error, 200, null)
         )
       })
+    })
+  })
+})
+
+describe('when getting a third party', () => {
+  let url: string
+  let thirdPartyId: string
+  let response: ServerResponse<ThirdParty> | ServerResponse<null>
+
+  beforeEach(() => {
+    thirdPartyId = 'aThirdPartyId'
+    url = `/v1/thirdParties/${thirdPartyId}`
+  })
+
+  describe('when the response status differs from being ok', () => {
+    beforeEach(() => {
+      nock(testUrl).get(url).reply(500)
+    })
+
+    it('should throw a client error with the "Unexpected response status" message', async () => {
+      await expect(client.getThirdParty(thirdPartyId)).rejects.toEqual(
+        new ClientError('Unexpected response status', 500, null)
+      )
+    })
+  })
+
+  describe("when the response body doesn't contain JSON data", () => {
+    beforeEach(() => {
+      nock(testUrl)
+        .get(url)
+        .reply(200, undefined, { 'Content-Type': 'text/html' })
+    })
+
+    it('should throw a client error with the "Unexpected content-type in response" message', async () => {
+      await expect(client.getThirdParty(thirdPartyId)).rejects.toEqual(
+        new ClientError('Unexpected content-type in response', 500, null)
+      )
+    })
+  })
+
+  describe('when the response body contains an error', () => {
+    beforeEach(() => {
+      response = {
+        ok: false,
+        error: 'Some error',
+        data: null
+      }
+      nock(testUrl).get(url).reply(200, response)
+    })
+
+    it('should throw a client error with the error in the body', async () => {
+      await expect(client.getThirdParty(thirdPartyId)).rejects.toEqual(
+        new ClientError(response.error!, 200, response.data)
+      )
+    })
+  })
+
+  describe('when the response body contains a third party', () => {
+    beforeEach(() => {
+      response = {
+        ok: true,
+        data: {
+          id: 'urn:decentraland:mumbai:collections-thirdparty:some-name',
+          root: '0xb6c6bc2f72b3fe1970806ec958341ad3cddef7b1a6ac347014ddba4f4b84151b',
+          name: 'Some name',
+          description: 'Some description',
+          managers: ['0x747c6f502272129bf1ba872a1903045b837ee86c'],
+          maxItems: '110',
+          totalItems: '0'
+        }
+      }
+      console.log(nock.pendingMocks)
+      nock(testUrl).get(url).reply(200, response)
+    })
+
+    it('should return the received third party', async () => {
+      await expect(client.getThirdParty(thirdPartyId)).resolves.toEqual(
+        response.data
+      )
     })
   })
 })

--- a/src/client/BuilderClient.ts
+++ b/src/client/BuilderClient.ts
@@ -195,7 +195,7 @@ export class BuilderClient {
 
   /**
    * The ID of the third party to retrieve.
-   * @param thirdPartyId - The content hash.
+   * @param thirdPartyId - The third party id (urn:decentraland:mumbai:collections-thirdparty:third-part-name).
    */
   public async getThirdParty(thirdPartyId: string): Promise<ThirdParty> {
     let thirdPartyResponse: Response

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -4,6 +4,25 @@ export type ServerResponse<T> = {
   error?: string
 }
 
+export enum ThirdPartyMetadataType {
+  THIRD_PARTY_V1 = 'third_party_v1'
+}
+
+export type ThirdPartyMetadata = {
+  type: ThirdPartyMetadataType
+  thirdParty: { name: string; description: string } | null
+}
+
+export type ThirdParty = {
+  id: string
+  root: string
+  name: string
+  description: string
+  managers: string[]
+  maxItems: string
+  totalItems: string
+}
+
 // START - Builder Server NFT
 // TODO: Abstract these types someplace else to avoid repetition
 


### PR DESCRIPTION
This PR adds a method to get a third party using the builder server's `/v1/thirdParties/:id`.
Closes #43 