### PR TITLE
feat: Allow item creation without ID in asset JSON

### DIFF
--- a/src/client/BuilderClient.spec.ts
+++ b/src/client/BuilderClient.spec.ts
@@ -817,7 +817,6 @@ describe('when getting a third party', () => {
           totalItems: '0'
         }
       }
-      console.log(nock.pendingMocks)
       nock(testUrl).get(url).reply(200, response)
     })
 

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -12,7 +12,7 @@ export type WearableRepresentation = {
 }
 
 export type AssetJSON = {
-  id: string
+  id?: string
   name: string
   urn?: string
   collectionId?: string

--- a/src/item/ItemFactory.spec.ts
+++ b/src/item/ItemFactory.spec.ts
@@ -1033,43 +1033,94 @@ describe('when creating a new item from an asset object', () => {
         }
       ]
     }
-    itemFactory.fromAsset(asset, contents)
   })
 
-  it('should create the built item configured with the values from the asset object and the new content with the provided content', () => {
-    return expect(itemFactory.build()).resolves.toEqual({
-      item: {
-        id: asset.id,
-        name: asset.name,
-        type: ItemType.WEARABLE,
-        thumbnail: THUMBNAIL_PATH,
-        collection_id: asset.collectionId,
-        urn: null,
-        data: {
-          category: asset.category,
-          hides: asset.hides,
-          replaces: asset.replaces,
-          tags: asset.tags,
-          representations: [
-            {
-              bodyShapes: [WearableBodyShape.MALE],
-              contents: [prefixedMaleModel],
-              mainFile: prefixedMaleModel,
-              overrideHides: [WearableCategory.EYES],
-              overrideReplaces: [WearableCategory.FACIAL_HAIR]
-            }
-          ]
-        },
-        rarity: asset.rarity,
-        description: asset.description,
-        metrics: asset.representations[0].metrics,
-        contents: maleHashedContent,
-        content_hash: null
-      } as LocalItem,
-      newContent: {
-        [prefixedMaleModel]: contents[modelPath],
-        [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH]
-      }
+  describe('and the id is defined', () => {
+    beforeEach(() => {
+      itemFactory.fromAsset(asset, contents)
+    })
+
+    it('should create the built item configured with the values from the asset object and the new content with the provided content', () => {
+      return expect(itemFactory.build()).resolves.toEqual({
+        item: {
+          id: asset.id,
+          name: asset.name,
+          type: ItemType.WEARABLE,
+          thumbnail: THUMBNAIL_PATH,
+          collection_id: asset.collectionId,
+          urn: null,
+          data: {
+            category: asset.category,
+            hides: asset.hides,
+            replaces: asset.replaces,
+            tags: asset.tags,
+            representations: [
+              {
+                bodyShapes: [WearableBodyShape.MALE],
+                contents: [prefixedMaleModel],
+                mainFile: prefixedMaleModel,
+                overrideHides: [WearableCategory.EYES],
+                overrideReplaces: [WearableCategory.FACIAL_HAIR]
+              }
+            ]
+          },
+          rarity: asset.rarity,
+          description: asset.description,
+          metrics: asset.representations[0].metrics,
+          contents: maleHashedContent,
+          content_hash: null
+        } as LocalItem,
+        newContent: {
+          [prefixedMaleModel]: contents[modelPath],
+          [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH]
+        }
+      })
+    })
+  })
+
+  describe('and the id is not defined', () => {
+    beforeEach(() => {
+      delete asset.id
+      itemFactory.fromAsset(asset, contents)
+    })
+
+    it('should create the built item configured with the values from the asset object, an auto generated id and the new content with the provided content', () => {
+      return expect(itemFactory.build()).resolves.toEqual({
+        item: {
+          id: expect.stringMatching(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+          ),
+          name: asset.name,
+          type: ItemType.WEARABLE,
+          thumbnail: THUMBNAIL_PATH,
+          collection_id: asset.collectionId,
+          urn: null,
+          data: {
+            category: asset.category,
+            hides: asset.hides,
+            replaces: asset.replaces,
+            tags: asset.tags,
+            representations: [
+              {
+                bodyShapes: [WearableBodyShape.MALE],
+                contents: [prefixedMaleModel],
+                mainFile: prefixedMaleModel,
+                overrideHides: [WearableCategory.EYES],
+                overrideReplaces: [WearableCategory.FACIAL_HAIR]
+              }
+            ]
+          },
+          rarity: asset.rarity,
+          description: asset.description,
+          metrics: asset.representations[0].metrics,
+          contents: maleHashedContent,
+          content_hash: null
+        } as LocalItem,
+        newContent: {
+          [prefixedMaleModel]: contents[modelPath],
+          [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH]
+        }
+      })
     })
   })
 })

--- a/src/item/ItemFactory.ts
+++ b/src/item/ItemFactory.ts
@@ -75,7 +75,7 @@ export class ItemFactory<X extends Content> {
    */
   public fromAsset(asset: AssetJSON, content: RawContent<X>): ItemFactory<X> {
     this.newItem({
-      id: asset.id,
+      id: asset.id ?? uuidV4(),
       name: asset.name,
       rarity: asset.rarity,
       category: asset.category,


### PR DESCRIPTION
In a later PR #25 , the creation of a new item changed to make the id optional, but the `asset.json` that is used to import information about an item isn't. This PR adds the mentioned functionality.