### PR TITLE
breaking: Support new wearable and builder configs

### DIFF
--- a/src/content/content.spec.ts
+++ b/src/content/content.spec.ts
@@ -1,6 +1,6 @@
 import { TextEncoder } from 'util'
 import { THUMBNAIL_PATH } from '../item/constants'
-import { BodyShapeType } from '../item/types'
+import { WearableBodyShape } from '../item/types'
 import { computeHashes, prefixContentName, sortContent } from './content'
 import { RawContent } from './types'
 
@@ -66,8 +66,8 @@ describe('when prefixing the content name', () => {
   const contentName = 'aContentName'
 
   it('should return the composition of the body shape and the content name', () => {
-    expect(prefixContentName(BodyShapeType.MALE, contentName)).toEqual(
-      `${BodyShapeType.MALE}/${contentName}`
+    expect(prefixContentName(WearableBodyShape.MALE, contentName)).toEqual(
+      `male/${contentName}`
     )
   })
 })
@@ -83,7 +83,7 @@ describe('when sorting the contents', () => {
 
   describe('when the contents are male', () => {
     it('should create a sorted contents object with the male contents', () => {
-      expect(sortContent(BodyShapeType.MALE, content)).toEqual({
+      expect(sortContent(WearableBodyShape.MALE, content)).toEqual({
         male: {
           'male/aContent': content.aContent
         },
@@ -98,28 +98,10 @@ describe('when sorting the contents', () => {
 
   describe('when the contents are female', () => {
     it('should create a sorted contents object with the female contents', () => {
-      expect(sortContent(BodyShapeType.FEMALE, content)).toEqual({
+      expect(sortContent(WearableBodyShape.FEMALE, content)).toEqual({
         male: {},
         female: { 'female/aContent': content.aContent },
         all: {
-          'female/aContent': content.aContent,
-          [THUMBNAIL_PATH]: content[THUMBNAIL_PATH]
-        }
-      })
-    })
-  })
-
-  describe('when the contents are both', () => {
-    it('should create a sorted contents object with the both contents', () => {
-      expect(sortContent(BodyShapeType.BOTH, content)).toEqual({
-        male: {
-          'male/aContent': content.aContent
-        },
-        female: {
-          'female/aContent': content.aContent
-        },
-        all: {
-          'male/aContent': content.aContent,
           'female/aContent': content.aContent,
           [THUMBNAIL_PATH]: content[THUMBNAIL_PATH]
         }

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -1,6 +1,6 @@
 import { hashV1 } from '@dcl/hashing'
 import { Buffer } from 'buffer'
-import { BodyShapeType } from '../item/types'
+import { WearableBodyShape } from '../item/types'
 import { THUMBNAIL_PATH } from '../item/constants'
 import { Content, HashedContent, RawContent, SortedContent } from './types'
 
@@ -61,10 +61,12 @@ async function makeContentFile(
  * @param contentKey - The name of the content.
  */
 export function prefixContentName(
-  bodyShape: BodyShapeType,
+  bodyShape: WearableBodyShape,
   contentKey: string
 ): string {
-  return `${bodyShape}/${contentKey}`
+  return `${
+    bodyShape === WearableBodyShape.MALE ? 'male' : 'female'
+  }/${contentKey}`
 }
 
 /**
@@ -75,16 +77,16 @@ export function prefixContentName(
  * @param contents - The contents to be sorted.
  */
 export function sortContent<T extends Content>(
-  bodyShape: BodyShapeType,
+  bodyShape: WearableBodyShape,
   contents: RawContent<T>
 ): SortedContent<T> {
   const male =
-    bodyShape === BodyShapeType.BOTH || bodyShape === BodyShapeType.MALE
-      ? prefixContents(BodyShapeType.MALE, contents)
+    bodyShape === WearableBodyShape.MALE
+      ? prefixContents(WearableBodyShape.MALE, contents)
       : {}
   const female =
-    bodyShape === BodyShapeType.BOTH || bodyShape === BodyShapeType.FEMALE
-      ? prefixContents(BodyShapeType.FEMALE, contents)
+    bodyShape === WearableBodyShape.FEMALE
+      ? prefixContents(WearableBodyShape.FEMALE, contents)
       : {}
   const all = {
     [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH],
@@ -103,7 +105,7 @@ export function sortContent<T extends Content>(
  * @param contents - The contents which keys are going to be prefixed.
  */
 function prefixContents<T extends Content>(
-  bodyShape: BodyShapeType,
+  bodyShape: WearableBodyShape,
   contents: RawContent<T>
 ): RawContent<T> {
   return Object.keys(contents).reduce(

--- a/src/files/constants.ts
+++ b/src/files/constants.ts
@@ -1,2 +1,3 @@
 export const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2MB
-export const ASSET_MANIFEST = 'asset.json'
+export const WEARABLE_MANIFEST = 'wearable.json'
+export const BUILDER_MANIFEST = 'builder.json'

--- a/src/files/files.errors.ts
+++ b/src/files/files.errors.ts
@@ -21,7 +21,7 @@ export class FileTooBigError extends Error {
   }
 }
 
-export class InvalidAssetFileError extends Error {
+export class InvalidBuilderConfigFileError extends Error {
   public getErrors():
     | ErrorObject<string, Record<string, unknown>, unknown>[]
     | null
@@ -34,7 +34,24 @@ export class InvalidAssetFileError extends Error {
       | ErrorObject<string, Record<string, unknown>, unknown>[]
       | null
   ) {
-    super('The asset file is invalid')
+    super('The builder config file is invalid')
+  }
+}
+
+export class InvalidWearableConfigFileError extends Error {
+  public getErrors():
+    | ErrorObject<string, Record<string, unknown>, unknown>[]
+    | null
+    | undefined {
+    return this.errors
+  }
+
+  constructor(
+    private errors?:
+      | ErrorObject<string, Record<string, unknown>, unknown>[]
+      | null
+  ) {
+    super('The wearable config file is invalid')
   }
 }
 

--- a/src/files/schemas.ts
+++ b/src/files/schemas.ts
@@ -1,53 +1,69 @@
-import { BodyShapeType, WearableCategory, Rarity } from '../item/types'
+import { JSONSchema, WearableRepresentation } from '@dcl/schemas'
+import { WearableCategory, Rarity } from '../item/types'
+import { BuilderConfig, WearableConfig } from './types'
 
-const WearableRepresentationSchema = {
+export const BuilderConfigSchema: JSONSchema<BuilderConfig> = {
   type: 'object',
   properties: {
-    bodyShape: {
+    id: {
       type: 'string',
-      enum: Object.values(BodyShapeType)
+      nullable: true
     },
-    mainFile: {
-      type: 'string'
-    },
-    contents: {
-      type: 'array',
-      items: { type: 'string' }
-    },
-    overrideHides: {
-      type: 'array',
-      items: WearableCategory.schema
-    },
-    overrideReplaces: {
-      type: 'array',
-      items: WearableCategory.schema
+    collectionId: {
+      type: 'string',
+      nullable: true
     }
   },
-  required: ['bodyShape', 'mainFile', 'contents'],
-  additionalProperties: false
+  additionalProperties: false,
+  required: []
 }
 
-export const AssetJSONSchema = {
+export const WearableConfigSchema: JSONSchema<WearableConfig> = {
   type: 'object',
   properties: {
-    id: { type: 'string', format: 'uuid' },
-    collectionId: { type: 'string', format: 'uuid' },
-    name: { type: 'string' },
-    description: { type: 'string' },
-    urn: { type: 'string' },
-    rarity: Rarity.schema,
-    category: WearableCategory.schema,
-    hides: {
-      type: 'array',
-      items: WearableCategory.schema
+    id: {
+      type: 'string',
+      nullable: true
     },
-    replaces: {
-      type: 'array',
-      items: WearableCategory.schema
+    description: {
+      type: 'string',
+      nullable: true
     },
-    tags: { type: 'array', items: { type: 'string' } },
-    representations: { type: 'array', items: WearableRepresentationSchema }
+    rarity: {
+      ...Rarity.schema,
+      nullable: true
+    },
+    name: {
+      type: 'string'
+    },
+    data: {
+      type: 'object',
+      properties: {
+        replaces: {
+          type: 'array',
+          items: WearableCategory.schema
+        },
+        hides: {
+          type: 'array',
+          items: WearableCategory.schema
+        },
+        tags: {
+          type: 'array',
+          items: {
+            type: 'string',
+            minLength: 1
+          }
+        },
+        representations: {
+          type: 'array',
+          items: WearableRepresentation.schema,
+          minItems: 1
+        },
+        category: WearableCategory.schema
+      },
+      required: ['replaces', 'hides', 'tags', 'representations', 'category']
+    }
   },
-  required: ['name', 'rarity', 'category', 'representations'],
-  additionalProperties: false
+  additionalProperties: false,
+  required: ['name', 'data']
 }

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -1,32 +1,31 @@
-import { Rarity } from '@dcl/schemas'
+import { Wearable } from '@dcl/schemas'
 import { Content, RawContent } from '../content/types'
-import { BodyShapeType, WearableCategory, ModelMetrics } from '../item/types'
 
-export type WearableRepresentation = {
-  bodyShape: BodyShapeType
-  mainFile: string
-  contents: string[]
-  overrideHides?: WearableCategory[]
-  overrideReplaces?: WearableCategory[]
-  metrics?: ModelMetrics
+export type WearableConfig = Omit<
+  Wearable,
+  | 'id'
+  | 'collectionAddress'
+  | 'content'
+  | 'merkleProof'
+  | 'thumbnail'
+  | 'image'
+  | 'i18n'
+  | 'metrics'
+  | 'menuBarIcon'
+  | 'description'
+> & {
+  id?: string
+  description?: string
 }
 
-export type AssetJSON = {
+export type BuilderConfig = {
   id?: string
-  name: string
-  urn?: string
   collectionId?: string
-  description?: string
-  category: WearableCategory
-  rarity: Rarity
-  hides?: WearableCategory[]
-  replaces?: WearableCategory[]
-  tags?: string[]
-  representations: WearableRepresentation[]
 }
 
 export type LoadedFile<T extends Content> = {
   content: RawContent<T>
-  asset?: AssetJSON
+  wearable?: WearableConfig
+  builder?: BuilderConfig
   mainModel?: string
 }

--- a/src/item/ItemFactory.spec.ts
+++ b/src/item/ItemFactory.spec.ts
@@ -1,16 +1,14 @@
 import { Rarity, WearableRepresentation } from '@dcl/schemas'
 import { prefixContentName } from '../content/content'
 import { Content } from '../content/types'
-import { AssetJSON } from '../files/types'
+import { BuilderConfig, WearableConfig } from '../files/types'
 import { toCamelCase } from '../test-utils/string'
-import { IMAGE_PATH, THUMBNAIL_PATH } from './constants'
+import { DEFAULT_METRICS, IMAGE_PATH, THUMBNAIL_PATH } from './constants'
 import { ItemFactory } from './ItemFactory'
 import {
-  BodyShapeType,
   BuiltItem,
   ItemType,
   LocalItem,
-  ModelMetrics,
   WearableBodyShape,
   WearableCategory
 } from './types'
@@ -114,13 +112,12 @@ let prefixedFemaleModel: string
 let contents: Record<string, Uint8Array>
 let maleHashedContent: Record<string, string>
 let femaleHashedContent: Record<string, string>
-let metrics: ModelMetrics
 let maleRepresentation: WearableRepresentation
 let femaleRepresentation: WearableRepresentation
 
 beforeEach(() => {
-  prefixedMaleModel = prefixContentName(BodyShapeType.MALE, modelPath)
-  prefixedFemaleModel = prefixContentName(BodyShapeType.FEMALE, modelPath)
+  prefixedMaleModel = prefixContentName(WearableBodyShape.MALE, modelPath)
+  prefixedFemaleModel = prefixContentName(WearableBodyShape.FEMALE, modelPath)
   itemFactory = new ItemFactory()
   contents = {
     [modelPath]: new Uint8Array([1, 2, 3]),
@@ -151,14 +148,6 @@ beforeEach(() => {
     contents: [prefixedFemaleModel],
     overrideReplaces: [],
     overrideHides: []
-  }
-  metrics = {
-    triangles: 100,
-    materials: 101,
-    meshes: 102,
-    bodies: 103,
-    entities: 104,
-    textures: 105
   }
 })
 
@@ -222,27 +211,13 @@ describe('when creating a new item', () => {
 })
 
 describe('when adding a representation to an item', () => {
-  let anotherMetrics: ModelMetrics
-
-  beforeEach(() => {
-    anotherMetrics = {
-      triangles: 106,
-      materials: 107,
-      meshes: 108,
-      bodies: 109,
-      entities: 110,
-      textures: 111
-    }
-  })
-
   describe('and the item was not initialized', () => {
     it('should throw an error signaling that the item has not been initialized', () => {
       expect(() =>
         itemFactory.withRepresentation(
-          BodyShapeType.MALE,
+          WearableBodyShape.MALE,
           modelPath,
-          contents,
-          metrics
+          contents
         )
       ).toThrow('Item has not been initialized')
     })
@@ -257,20 +232,18 @@ describe('when adding a representation to an item', () => {
       describe('and the item already contained a male representation', () => {
         beforeEach(() => {
           itemFactory.withRepresentation(
-            BodyShapeType.MALE,
+            WearableBodyShape.MALE,
             modelPath,
-            contents,
-            metrics
+            contents
           )
         })
 
         it('should throw an error signaling that the item already contained that body shape', () => {
           expect(() =>
             itemFactory.withRepresentation(
-              BodyShapeType.MALE,
+              WearableBodyShape.MALE,
               modelPath,
-              contents,
-              metrics
+              contents
             )
           ).toThrow(
             "The representation that you're about to add already exists in the item"
@@ -281,17 +254,15 @@ describe('when adding a representation to an item', () => {
       describe('and the item already contained a female representation', () => {
         beforeEach(async () => {
           itemFactory.withRepresentation(
-            BodyShapeType.FEMALE,
+            WearableBodyShape.FEMALE,
             modelPath,
-            contents,
-            metrics
+            contents
           )
 
           itemFactory.withRepresentation(
-            BodyShapeType.MALE,
+            WearableBodyShape.MALE,
             modelPath,
-            contents,
-            anotherMetrics
+            contents
           )
           const createdItem = await itemFactory.build()
           newContent = createdItem.newContent
@@ -303,10 +274,6 @@ describe('when adding a representation to an item', () => {
             femaleRepresentation,
             maleRepresentation
           ])
-        })
-
-        it('should have set the new metrics', () => {
-          expect(item.metrics).toEqual(anotherMetrics)
         })
 
         it("should have added the male contents to the item's contents", () => {
@@ -326,37 +293,12 @@ describe('when adding a representation to an item', () => {
         })
       })
 
-      describe('and the item already contained a "both" representation', () => {
-        beforeEach(() => {
-          itemFactory.withRepresentation(
-            BodyShapeType.BOTH,
-            modelPath,
-            contents,
-            metrics
-          )
-        })
-
-        it('should throw an error signaling that the item already contained that body shape', () => {
-          expect(() =>
-            itemFactory.withRepresentation(
-              BodyShapeType.MALE,
-              modelPath,
-              contents,
-              metrics
-            )
-          ).toThrow(
-            "The representation that you're about to add already exists in the item"
-          )
-        })
-      })
-
-      describe('and the item did not contain a male nor a "both" representation', () => {
+      describe('and the item did not contain a male representation', () => {
         beforeEach(async () => {
           itemFactory.withRepresentation(
-            BodyShapeType.MALE,
+            WearableBodyShape.MALE,
             modelPath,
-            contents,
-            metrics
+            contents
           )
           const createdItem = await itemFactory.build()
           newContent = createdItem.newContent
@@ -365,10 +307,6 @@ describe('when adding a representation to an item', () => {
 
         it('should have created the male representation', () => {
           expect(item.data.representations).toEqual([maleRepresentation])
-        })
-
-        it('should have set the metrics', () => {
-          expect(item.metrics).toEqual(metrics)
         })
 
         it("should have added the contents to the item's contents", () => {
@@ -392,44 +330,18 @@ describe('when adding a representation to an item', () => {
       describe('and the item already contained a female representation', () => {
         beforeEach(() => {
           itemFactory.withRepresentation(
-            BodyShapeType.FEMALE,
+            WearableBodyShape.FEMALE,
             modelPath,
-            contents,
-            metrics
+            contents
           )
         })
 
         it('should throw an error signaling that the item already contained that body shape', () => {
           expect(() =>
             itemFactory.withRepresentation(
-              BodyShapeType.FEMALE,
+              WearableBodyShape.FEMALE,
               modelPath,
-              contents,
-              metrics
-            )
-          ).toThrow(
-            "The representation that you're about to add already exists in the item"
-          )
-        })
-      })
-
-      describe('and the item already contained a "both" representation', () => {
-        beforeEach(() => {
-          itemFactory.withRepresentation(
-            BodyShapeType.BOTH,
-            modelPath,
-            contents,
-            metrics
-          )
-        })
-
-        it('should throw an error signaling that the item already contained that body shape', () => {
-          expect(() =>
-            itemFactory.withRepresentation(
-              BodyShapeType.FEMALE,
-              modelPath,
-              contents,
-              metrics
+              contents
             )
           ).toThrow(
             "The representation that you're about to add already exists in the item"
@@ -440,17 +352,15 @@ describe('when adding a representation to an item', () => {
       describe('and the item already contained a male representation', () => {
         beforeEach(async () => {
           itemFactory.withRepresentation(
-            BodyShapeType.MALE,
+            WearableBodyShape.MALE,
             modelPath,
-            contents,
-            metrics
+            contents
           )
 
           itemFactory.withRepresentation(
-            BodyShapeType.FEMALE,
+            WearableBodyShape.FEMALE,
             modelPath,
-            contents,
-            anotherMetrics
+            contents
           )
           const createdItem = await itemFactory.build()
           newContent = createdItem.newContent
@@ -462,10 +372,6 @@ describe('when adding a representation to an item', () => {
             maleRepresentation,
             femaleRepresentation
           ])
-        })
-
-        it('should have set the new metrics', () => {
-          expect(item.metrics).toEqual(anotherMetrics)
         })
 
         it("should have added the female contents to the item's contents", () => {
@@ -485,13 +391,12 @@ describe('when adding a representation to an item', () => {
         })
       })
 
-      describe('and the item did not contain a female nor a "both" representation', () => {
+      describe('and the item did not contain a female representation', () => {
         beforeEach(async () => {
           itemFactory.withRepresentation(
-            BodyShapeType.FEMALE,
+            WearableBodyShape.FEMALE,
             modelPath,
-            contents,
-            metrics
+            contents
           )
           const createdItem = await itemFactory.build()
           newContent = createdItem.newContent
@@ -500,10 +405,6 @@ describe('when adding a representation to an item', () => {
 
         it('should have created the male representation', () => {
           expect(item.data.representations).toEqual([femaleRepresentation])
-        })
-
-        it('should have set the given metrics', () => {
-          expect(item.metrics).toEqual(metrics)
         })
 
         it("should have added the contents to the item's contents", () => {
@@ -522,97 +423,6 @@ describe('when adding a representation to an item', () => {
         })
       })
     })
-
-    describe('and the representation is for a male and female body shapes', () => {
-      describe('and the item already contained a female representation', () => {
-        beforeEach(() => {
-          itemFactory.withRepresentation(
-            BodyShapeType.FEMALE,
-            modelPath,
-            contents,
-            metrics
-          )
-        })
-
-        it('should throw an error signaling that the item already contained that body shape', () => {
-          expect(() =>
-            itemFactory.withRepresentation(
-              BodyShapeType.BOTH,
-              modelPath,
-              contents,
-              metrics
-            )
-          ).toThrow(
-            "The representation that you're about to add already exists in the item"
-          )
-        })
-      })
-
-      describe('and the item already contained a male representation', () => {
-        beforeEach(() => {
-          itemFactory.withRepresentation(
-            BodyShapeType.MALE,
-            modelPath,
-            contents,
-            metrics
-          )
-        })
-
-        it('should throw an error signaling that the item already contained that body shape', () => {
-          expect(() =>
-            itemFactory.withRepresentation(
-              BodyShapeType.BOTH,
-              modelPath,
-              contents,
-              metrics
-            )
-          ).toThrow(
-            "The representation that you're about to add already exists in the item"
-          )
-        })
-      })
-
-      describe('and the item did not contain any representation', () => {
-        beforeEach(async () => {
-          itemFactory.withRepresentation(
-            BodyShapeType.BOTH,
-            modelPath,
-            contents,
-            metrics
-          )
-          const createdItem = await itemFactory.build()
-          newContent = createdItem.newContent
-          item = createdItem.item
-        })
-
-        it('should have created the male representation', () => {
-          expect(item.data.representations).toEqual([
-            maleRepresentation,
-            femaleRepresentation
-          ])
-        })
-
-        it('should have set the given metrics', () => {
-          expect(item.metrics).toEqual(metrics)
-        })
-
-        it("should have added the contents to the item's contents", () => {
-          expect(item).toEqual(
-            expect.objectContaining({
-              contents: { ...maleHashedContent, ...femaleHashedContent }
-            })
-          )
-        })
-
-        it('should have added the contents to the new contents', () => {
-          expect(newContent).toEqual({
-            [prefixedMaleModel]: contents[modelPath],
-            [prefixedFemaleModel]: contents[modelPath],
-            [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH]
-          })
-        })
-      })
-    })
   })
 })
 
@@ -620,7 +430,7 @@ describe('when removing a representation', () => {
   describe('and the item was not initialized', () => {
     it('should throw an error signaling that the item has not been initialized', () => {
       expect(() =>
-        itemFactory.withoutRepresentation(BodyShapeType.MALE)
+        itemFactory.withoutRepresentation(WearableBodyShape.MALE)
       ).toThrow('Item has not been initialized')
     })
   })
@@ -629,7 +439,7 @@ describe('when removing a representation', () => {
     describe("and the item doesn't have any representations", () => {
       beforeEach(async () => {
         createBasicItem(itemFactory)
-        itemFactory.withoutRepresentation(BodyShapeType.MALE)
+        itemFactory.withoutRepresentation(WearableBodyShape.MALE)
       })
 
       it('should not do anything', () => {
@@ -643,61 +453,13 @@ describe('when removing a representation', () => {
       })
     })
 
-    describe('and the body shape to remove is both', () => {
-      beforeEach(() => {
-        createBasicItem(itemFactory)
-        itemFactory
-          .withRepresentation(BodyShapeType.MALE, modelPath, contents, metrics)
-          .withRepresentation(
-            BodyShapeType.FEMALE,
-            modelPath,
-            contents,
-            metrics
-          )
-          .withoutRepresentation(BodyShapeType.BOTH)
-      })
-
-      it('should remove all representations', () => {
-        return expect(itemFactory.build()).resolves.toEqual(
-          expect.objectContaining({
-            item: expect.objectContaining({
-              data: expect.objectContaining({ representations: [] })
-            })
-          })
-        )
-      })
-
-      it('should remove all contents', () => {
-        return expect(itemFactory.build()).resolves.toEqual(
-          expect.objectContaining({
-            item: expect.objectContaining({
-              contents: {}
-            })
-          })
-        )
-      })
-
-      it('should remove all new contents', () => {
-        return expect(itemFactory.build()).resolves.toEqual(
-          expect.objectContaining({
-            newContent: {}
-          })
-        )
-      })
-    })
-
     describe('and the body shape to remove is female, having a female and male representations', () => {
       beforeEach(() => {
         createBasicItem(itemFactory)
         itemFactory
-          .withRepresentation(BodyShapeType.MALE, modelPath, contents, metrics)
-          .withRepresentation(
-            BodyShapeType.FEMALE,
-            modelPath,
-            contents,
-            metrics
-          )
-          .withoutRepresentation(BodyShapeType.FEMALE)
+          .withRepresentation(WearableBodyShape.MALE, modelPath, contents)
+          .withRepresentation(WearableBodyShape.FEMALE, modelPath, contents)
+          .withoutRepresentation(WearableBodyShape.FEMALE)
       })
 
       it('should remove the female representations', () => {
@@ -738,17 +500,12 @@ describe('when removing a representation', () => {
       beforeEach(() => {
         createBasicItem(itemFactory)
         itemFactory
-          .withRepresentation(
-            BodyShapeType.FEMALE,
-            modelPath,
-            contents,
-            metrics
-          )
-          .withRepresentation(BodyShapeType.MALE, modelPath, contents, metrics)
-          .withoutRepresentation(BodyShapeType.MALE)
+          .withRepresentation(WearableBodyShape.FEMALE, modelPath, contents)
+          .withRepresentation(WearableBodyShape.MALE, modelPath, contents)
+          .withoutRepresentation(WearableBodyShape.MALE)
       })
 
-      it('should remove the female representations', () => {
+      it('should remove the male representations', () => {
         return expect(itemFactory.build()).resolves.toEqual(
           expect.objectContaining({
             item: expect.objectContaining({
@@ -760,7 +517,7 @@ describe('when removing a representation', () => {
         )
       })
 
-      it('should remove the female contents', () => {
+      it('should remove the male contents', () => {
         return expect(itemFactory.build()).resolves.toEqual(
           expect.objectContaining({
             item: expect.objectContaining({
@@ -770,7 +527,7 @@ describe('when removing a representation', () => {
         )
       })
 
-      it('should remove the female new contents', () => {
+      it('should remove the male new contents', () => {
         return expect(itemFactory.build()).resolves.toEqual(
           expect.objectContaining({
             newContent: {
@@ -788,7 +545,7 @@ describe("when setting the item's thumbnail", () => {
   describe('and the item was not initialized', () => {
     it('should throw an error signaling that the item has not been initialized', () => {
       expect(() =>
-        itemFactory.withoutRepresentation(BodyShapeType.MALE)
+        itemFactory.withoutRepresentation(WearableBodyShape.MALE)
       ).toThrow('Item has not been initialized')
     })
   })
@@ -807,10 +564,9 @@ describe("when setting the item's thumbnail", () => {
         newThumbnailHash =
           'bafkreigj4dzk52sis4yszi77peaijhoo5pmbvdww33byqkku62u2apv5e4'
         itemFactory.withRepresentation(
-          BodyShapeType.MALE,
+          WearableBodyShape.MALE,
           modelPath,
-          contents,
-          metrics
+          contents
         )
         itemFactory.withThumbnail(newThumbnail)
       })
@@ -892,7 +648,7 @@ describe("when setting the item's contents", () => {
     describe('and the item already contained contents', () => {
       beforeEach(() => {
         itemFactory
-          .withRepresentation(BodyShapeType.MALE, modelPath, contents, metrics)
+          .withRepresentation(WearableBodyShape.MALE, modelPath, contents)
           .withContent(newContent)
       })
 
@@ -1008,52 +764,58 @@ describe("when setting the item's image", () => {
   })
 })
 
-describe('when creating a new item from an asset object', () => {
-  let asset: AssetJSON
+describe('when creating a new item from a wearable and builder config file objects', () => {
+  let wearableConfig: WearableConfig
+  let builderConfig: BuilderConfig
 
   beforeEach(async () => {
-    asset = {
-      id: 'f12313b4-a76b-4c9e-a2a3-ab460f59bd67',
+    wearableConfig = {
+      id: 'urn:decentraland:matic:collections-thirdparty:third-party-id:collection-id:item-id',
       name: 'test',
-      category: WearableCategory.EYEBROWS,
       rarity: Rarity.COMMON,
-      collectionId: '7c3af3a0-9ea9-4cc7-a137-dc1f1f6c0871',
       description: 'a description',
-      hides: [WearableCategory.FEET],
-      replaces: [WearableCategory.HAIR],
-      tags: ['tag1', 'tag2'],
-      representations: [
-        {
-          bodyShape: BodyShapeType.MALE,
-          mainFile: modelPath,
-          contents: [modelPath, THUMBNAIL_PATH],
-          overrideHides: [WearableCategory.EYES],
-          overrideReplaces: [WearableCategory.FACIAL_HAIR],
-          metrics
-        }
-      ]
+      data: {
+        category: WearableCategory.EYEBROWS,
+        hides: [WearableCategory.FEET],
+        replaces: [WearableCategory.HAIR],
+        tags: ['tag1', 'tag2'],
+        representations: [
+          {
+            bodyShapes: [WearableBodyShape.MALE],
+            mainFile: modelPath,
+            contents: [modelPath, THUMBNAIL_PATH],
+            overrideHides: [WearableCategory.EYES],
+            overrideReplaces: [WearableCategory.FACIAL_HAIR]
+          }
+        ]
+      }
+    }
+
+    builderConfig = {
+      id: 'f12313b4-a76b-4c9e-a2a3-ab460f59bd67',
+      collectionId: '7c3af3a0-9ea9-4cc7-a137-dc1f1f6c0871'
     }
   })
 
-  describe('and the id is defined', () => {
+  describe('and the builder config is provided and the id is defined', () => {
     beforeEach(() => {
-      itemFactory.fromAsset(asset, contents)
+      itemFactory.fromConfig(wearableConfig, contents, builderConfig)
     })
 
-    it('should create the built item configured with the values from the asset object and the new content with the provided content', () => {
+    it('should create the built item configured with the values from the builder and wearable config objects and the new content with the provided content', () => {
       return expect(itemFactory.build()).resolves.toEqual({
         item: {
-          id: asset.id,
-          name: asset.name,
+          id: builderConfig.id,
+          name: wearableConfig.name,
           type: ItemType.WEARABLE,
           thumbnail: THUMBNAIL_PATH,
-          collection_id: asset.collectionId,
-          urn: null,
+          collection_id: builderConfig.collectionId,
+          urn: wearableConfig.id,
           data: {
-            category: asset.category,
-            hides: asset.hides,
-            replaces: asset.replaces,
-            tags: asset.tags,
+            category: wearableConfig.data.category,
+            hides: wearableConfig.data.hides,
+            replaces: wearableConfig.data.replaces,
+            tags: wearableConfig.data.tags,
             representations: [
               {
                 bodyShapes: [WearableBodyShape.MALE],
@@ -1064,11 +826,11 @@ describe('when creating a new item from an asset object', () => {
               }
             ]
           },
-          rarity: asset.rarity,
-          description: asset.description,
-          metrics: asset.representations[0].metrics,
+          rarity: wearableConfig.rarity,
+          description: wearableConfig.description,
           contents: maleHashedContent,
-          content_hash: null
+          content_hash: null,
+          metrics: DEFAULT_METRICS
         } as LocalItem,
         newContent: {
           [prefixedMaleModel]: contents[modelPath],
@@ -1078,28 +840,28 @@ describe('when creating a new item from an asset object', () => {
     })
   })
 
-  describe('and the id is not defined', () => {
+  describe('and the builder config is provided and the id is not defined', () => {
     beforeEach(() => {
-      delete asset.id
-      itemFactory.fromAsset(asset, contents)
+      delete wearableConfig.id
+      itemFactory.fromConfig(wearableConfig, contents, builderConfig)
     })
 
-    it('should create the built item configured with the values from the asset object, an auto generated id and the new content with the provided content', () => {
+    it('should create the built item configured with the values from the wearable and the builder config object, an auto generated id and the new content with the provided content', () => {
       return expect(itemFactory.build()).resolves.toEqual({
         item: {
           id: expect.stringMatching(
             /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
           ),
-          name: asset.name,
+          name: wearableConfig.name,
           type: ItemType.WEARABLE,
           thumbnail: THUMBNAIL_PATH,
-          collection_id: asset.collectionId,
+          collection_id: builderConfig.collectionId,
           urn: null,
           data: {
-            category: asset.category,
-            hides: asset.hides,
-            replaces: asset.replaces,
-            tags: asset.tags,
+            category: wearableConfig.data.category,
+            hides: wearableConfig.data.hides,
+            replaces: wearableConfig.data.replaces,
+            tags: wearableConfig.data.tags,
             representations: [
               {
                 bodyShapes: [WearableBodyShape.MALE],
@@ -1110,11 +872,57 @@ describe('when creating a new item from an asset object', () => {
               }
             ]
           },
-          rarity: asset.rarity,
-          description: asset.description,
-          metrics: asset.representations[0].metrics,
+          rarity: wearableConfig.rarity,
+          description: wearableConfig.description,
           contents: maleHashedContent,
-          content_hash: null
+          content_hash: null,
+          metrics: DEFAULT_METRICS
+        } as LocalItem,
+        newContent: {
+          [prefixedMaleModel]: contents[modelPath],
+          [THUMBNAIL_PATH]: contents[THUMBNAIL_PATH]
+        }
+      })
+    })
+  })
+
+  describe('and the builder config is not provided', () => {
+    beforeEach(() => {
+      delete wearableConfig.id
+      itemFactory.fromConfig(wearableConfig, contents, builderConfig)
+    })
+
+    it('should create the built item configured with the values from the wearable config object, an auto generated id and the new content with the provided content', () => {
+      return expect(itemFactory.build()).resolves.toEqual({
+        item: {
+          id: expect.stringMatching(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+          ),
+          name: wearableConfig.name,
+          type: ItemType.WEARABLE,
+          thumbnail: THUMBNAIL_PATH,
+          collection_id: builderConfig.collectionId,
+          urn: null,
+          data: {
+            category: wearableConfig.data.category,
+            hides: wearableConfig.data.hides,
+            replaces: wearableConfig.data.replaces,
+            tags: wearableConfig.data.tags,
+            representations: [
+              {
+                bodyShapes: [WearableBodyShape.MALE],
+                contents: [prefixedMaleModel],
+                mainFile: prefixedMaleModel,
+                overrideHides: [WearableCategory.EYES],
+                overrideReplaces: [WearableCategory.FACIAL_HAIR]
+              }
+            ]
+          },
+          rarity: wearableConfig.rarity,
+          description: wearableConfig.description,
+          contents: maleHashedContent,
+          content_hash: null,
+          metrics: DEFAULT_METRICS
         } as LocalItem,
         newContent: {
           [prefixedMaleModel]: contents[modelPath],

--- a/src/item/types.ts
+++ b/src/item/types.ts
@@ -1,4 +1,9 @@
-import { Rarity, WearableCategory, WearableRepresentation } from '@dcl/schemas'
+import {
+  Rarity,
+  WearableCategory,
+  WearableRepresentation,
+  WearableBodyShape
+} from '@dcl/schemas'
 import { Content, RawContent } from '../content/types'
 
 export type RemoteItem = {
@@ -52,18 +57,6 @@ export enum ItemType {
   WEARABLE = 'wearable'
 }
 
-export enum BodyShapeType {
-  // DCL Schemas doesn't have both
-  BOTH = 'both',
-  MALE = 'male',
-  FEMALE = 'female'
-}
-
-export enum WearableBodyShape {
-  MALE = 'urn:decentraland:off-chain:base-avatars:BaseMale',
-  FEMALE = 'urn:decentraland:off-chain:base-avatars:BaseFemale'
-}
-
 export type ModelMetrics = {
   triangles: number
   materials: number
@@ -86,4 +79,4 @@ export type BuiltItem<T extends Content> = {
   newContent: RawContent<T>
 }
 
-export { Rarity, WearableCategory }
+export { Rarity, WearableCategory, WearableBodyShape }


### PR DESCRIPTION
This PR removes the support for the `asset.json` file and adds support for the `wearable.json` and `builder.json` files.