### PR TITLE
fix: Use Scene schema from commons schemas

### DIFF
--- a/src/files/files.ts
+++ b/src/files/files.ts
@@ -2,6 +2,8 @@ import JSZip, { OutputType } from 'jszip'
 import { basename } from 'path'
 import Ajv from 'ajv'
 import addAjvFormats from 'ajv-formats'
+import addAjvKeywords from 'ajv-keywords'
+import addAjvErrors from 'ajv-errors'
 import { Content, RawContent } from '../content/types'
 import { THUMBNAIL_PATH } from '../item/constants'
 import { TextDecoder as NodeTextDecoder } from 'util'
@@ -27,8 +29,12 @@ import {
   WrongExtensionError
 } from './files.errors'
 
-const ajv = new Ajv({ $data: true })
+const ajv = new Ajv({ $data: true, allErrors: true })
+
 addAjvFormats(ajv)
+addAjvKeywords(ajv)
+addAjvErrors(ajv, { singleError: true })
+
 const validator = ajv
   .addSchema(WearableConfigSchema, 'WearableConfig')
   .addSchema(SceneConfigSchema, 'SceneConfig')

--- a/src/files/schemas.ts
+++ b/src/files/schemas.ts
@@ -1,7 +1,7 @@
 import {
   HideableWearableCategory,
   JSONSchema,
-  SceneParcels,
+  Scene,
   WearableRepresentation
 } from '@dcl/schemas'
 import { WearableCategory, Rarity } from '../item/types'
@@ -73,27 +73,4 @@ export const WearableConfigSchema: JSONSchema<WearableConfig> = {
   required: ['name', 'data']
 }
 
-export const SceneConfigSchema: JSONSchema<SceneConfig> = {
-  type: 'object',
-  properties: {
-    id: {
-      type: 'string',
-      nullable: true
-    },
-    main: {
-      description: "File that contains the entry point of the scene's code",
-      type: 'string',
-      minLength: 1
-    },
-    scene: SceneParcels.schema,
-    requiredPermissions: {
-      type: 'array',
-      items: {
-        type: 'string'
-      },
-      nullable: true
-    }
-  },
-  additionalProperties: false,
-  required: ['main', 'scene']
-}
+export const SceneConfigSchema: JSONSchema<SceneConfig> = Scene.schema

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -1,17 +1,5 @@
-import {
-  SceneParcels,
-  StandardProps,
-  ThirdPartyProps,
-  Wearable
-} from '@dcl/schemas'
+import { StandardProps, ThirdPartyProps, Wearable, Scene } from '@dcl/schemas'
 import { Content, RawContent } from '../content/types'
-
-export type SceneConfig = {
-  id?: string
-  main: string
-  scene: SceneParcels
-  requiredPermissions?: string[]
-}
 
 export type WearableConfig = Omit<
   Wearable & Partial<StandardProps> & Partial<ThirdPartyProps>,
@@ -34,6 +22,8 @@ export type BuilderConfig = {
   id?: string
   collectionId?: string
 }
+
+export type SceneConfig = Scene
 
 export type LoadedFile<T extends Content> = {
   content: RawContent<T>


### PR DESCRIPTION
Extend `ajv` to accept custom keywords and errors to use the `Scene.schema` from `common-schemas` lib.