### PR TITLE
feat: add flexibility to emote zip file

### DIFF
--- a/src/files/files.errors.ts
+++ b/src/files/files.errors.ts
@@ -55,23 +55,6 @@ export class InvalidWearableConfigFileError extends Error {
   }
 }
 
-export class InvalidEmoteConfigFileError extends Error {
-  public getErrors():
-    | ErrorObject<string, Record<string, unknown>, unknown>[]
-    | null
-    | undefined {
-    return this.errors
-  }
-
-  constructor(
-    private errors?:
-      | ErrorObject<string, Record<string, unknown>, unknown>[]
-      | null
-  ) {
-    super('The emote config file is invalid')
-  }
-}
-
 export class InvalidSceneConfigFileError extends Error {
   public getErrors():
     | ErrorObject<string, Record<string, unknown>, unknown>[]

--- a/src/files/files.spec.ts
+++ b/src/files/files.spec.ts
@@ -681,7 +681,7 @@ describe('when loading an item file', () => {
               [THUMBNAIL_PATH]: thumbnailContent
             },
             emote: {
-              name: "Name"
+              name: 'Name'
             },
             mainModel
           })

--- a/src/files/files.ts
+++ b/src/files/files.ts
@@ -265,11 +265,20 @@ async function loadEmoteConfig<T extends Content>(
   file: T
 ): Promise<EmoteConfig> {
   const content = await readContent(file)
-  const validProperties = ['name', 'description', 'tags', 'rarity', 'category', 'play_mode']
+  const validProperties = [
+    'name',
+    'description',
+    'tags',
+    'rarity',
+    'category',
+    'play_mode'
+  ]
   const parsedContent = JSON.parse(content)
   validator.validate('EmoteConfig', parsedContent)
   const values = Object.keys(parsedContent).reduce((val, key) => {
-    const propertyHasErrors = validator.errors?.some(({ instancePath }) => instancePath.includes(key))
+    const propertyHasErrors = validator.errors?.some(({ instancePath }) =>
+      instancePath.includes(key)
+    )
     if (propertyHasErrors || !validProperties.includes(key)) {
       return val
     }

--- a/src/files/files.ts
+++ b/src/files/files.ts
@@ -31,7 +31,6 @@ import {
   FileNotFoundError,
   FileTooBigError,
   InvalidBuilderConfigFileError,
-  InvalidEmoteConfigFileError,
   InvalidWearableConfigFileError,
   ModelFileNotFoundError,
   WrongExtensionError
@@ -266,9 +265,18 @@ async function loadEmoteConfig<T extends Content>(
   file: T
 ): Promise<EmoteConfig> {
   const content = await readContent(file)
+  const validProperties = ['name', 'description', 'tags', 'rarity', 'category', 'play_mode']
   const parsedContent = JSON.parse(content)
-  if (!validator.validate('EmoteConfig', parsedContent)) {
-    throw new InvalidEmoteConfigFileError(validator.errors)
-  }
-  return parsedContent
+  validator.validate('EmoteConfig', parsedContent)
+  const values = Object.keys(parsedContent).reduce((val, key) => {
+    const propertyHasErrors = validator.errors?.some(({ instancePath }) => instancePath.includes(key))
+    if (propertyHasErrors || !validProperties.includes(key)) {
+      return val
+    }
+    return {
+      ...val,
+      [key]: parsedContent[key]
+    }
+  }, {})
+  return values
 }

--- a/src/files/schemas.ts
+++ b/src/files/schemas.ts
@@ -111,8 +111,16 @@ export const EmoteConfigSchema: JSONSchema<EmoteConfig> = {
     play_mode: {
       ...EmotePlayMode.schema,
       nullable: true
-    }
+    },
+    tags: {
+      type: 'array',
+      items: {
+        type: 'string',
+        minLength: 1
+      },
+      nullable: true
+    },
   },
-  additionalProperties: false,
+  additionalProperties: true,
   required: []
 }

--- a/src/files/schemas.ts
+++ b/src/files/schemas.ts
@@ -119,7 +119,7 @@ export const EmoteConfigSchema: JSONSchema<EmoteConfig> = {
         minLength: 1
       },
       nullable: true
-    },
+    }
   },
   additionalProperties: true,
   required: []

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -38,6 +38,7 @@ export type EmoteConfig = {
   category?: EmoteCategory
   rarity?: Rarity
   play_mode?: EmotePlayMode
+  tags?: string[]
 }
 
 export type SceneConfig = Scene


### PR DESCRIPTION
Add more flexibility on the validation of emote config file. If a field is invalid then we just ignore it instead of failing