### PR TITLE
fix: Compute zipped size as a whole

### DIFF
--- a/src/files/files.errors.ts
+++ b/src/files/files.errors.ts
@@ -1,5 +1,4 @@
 import { ErrorObject } from 'ajv'
-import { MAX_WEARABLE_FILE_SIZE, MAX_SKIN_FILE_SIZE } from './constants'
 import { FileType } from './types'
 
 export class WrongExtensionError extends Error {
@@ -35,7 +34,7 @@ export class FileTooBigError extends Error {
     private type: FileType
   ) {
     super(
-      `The file ${fileName} too big (${fileSize} bytes) but should be less than ${MAX_WEARABLE_FILE_SIZE} bytes for wearables and ${MAX_SKIN_FILE_SIZE} bytes for skins`
+      `The file ${fileName} too big (${fileSize} bytes) but should be less than ${maxFileSize} bytes for the ${type} type.`
     )
   }
 }

--- a/src/files/files.spec.ts
+++ b/src/files/files.spec.ts
@@ -725,7 +725,7 @@ describe('when loading an item file', () => {
       it('should throw an error signaling that the file is too big', () => {
         return expect(loadFile(fileName, zipFileContent)).rejects.toThrow(
           new FileTooBigError(
-            modelFile,
+            fileName,
             MAX_WEARABLE_FILE_SIZE + 1,
             MAX_WEARABLE_FILE_SIZE,
             FileType.WEARABLE
@@ -769,7 +769,7 @@ describe('when loading an item file', () => {
       it('should throw an error signaling that the file is too big', () => {
         return expect(loadFile(fileName, zipFileContent)).rejects.toThrow(
           new FileTooBigError(
-            modelFile,
+            fileName,
             MAX_SKIN_FILE_SIZE + 1,
             MAX_SKIN_FILE_SIZE,
             FileType.SKIN
@@ -796,7 +796,7 @@ describe('when loading an item file', () => {
       it('should throw an error signaling that the file is too big', () => {
         return expect(loadFile(fileName, zipFileContent)).rejects.toThrow(
           new FileTooBigError(
-            modelFile,
+            fileName,
             MAX_EMOTE_FILE_SIZE + 1,
             MAX_EMOTE_FILE_SIZE,
             FileType.EMOTE

--- a/src/files/files.ts
+++ b/src/files/files.ts
@@ -195,7 +195,7 @@ async function handleZippedModelFiles<T extends Content>(
     }
 
     // Check that the whole content size does not exceed the maximum allowed size
-    const isSkin = wearableData.category == WearableCategory.SKIN
+    const isSkin = wearableData.category === WearableCategory.SKIN
 
     if (isSkin && contentsSize > MAX_SKIN_FILE_SIZE) {
       throw new FileTooBigError(


### PR DESCRIPTION
This PR changes the way we compute the size of the zipped files by computing the size of the whole zip.