### PR TITLE
fix: SW file size

### DIFF
--- a/src/files/constants.ts
+++ b/src/files/constants.ts
@@ -4,6 +4,7 @@ export const MAX_THUMBNAIL_FILE_SIZE = 1024 * 1024 // 1MB
 export const MAX_WEARABLE_FILE_SIZE = 2 * 1024 * 1024 // 2MB
 export const MAX_EMOTE_FILE_SIZE = 2 * 1024 * 1024 // 2MB
 export const MAX_SKIN_FILE_SIZE = 8 * 1024 * 1024 // 8MB
+export const MAX_SMART_WEARABLE_FILE_SIZE = 3 * 1024 * 1024 // 3MB
 export const WEARABLE_MANIFEST = 'wearable.json'
 export const EMOTE_MANIFEST = 'emote.json'
 export const SCENE_MANIFEST = 'scene.json'

--- a/src/files/files.ts
+++ b/src/files/files.ts
@@ -15,7 +15,8 @@ import {
   MAX_SKIN_FILE_SIZE,
   MAX_WEARABLE_FILE_SIZE,
   MAX_THUMBNAIL_FILE_SIZE,
-  MAX_EMOTE_FILE_SIZE
+  MAX_EMOTE_FILE_SIZE,
+  MAX_SMART_WEARABLE_FILE_SIZE
 } from './constants'
 import {
   WearableConfig,
@@ -193,7 +194,7 @@ async function handleZippedModelFiles<T extends Content>(
         throw new FileNotFoundError(scene.main)
       }
     }
-
+    const isSmartWearable = !!scene && !!wearable
     // Check that the whole content size does not exceed the maximum allowed size
     const isSkin = wearableData.category === WearableCategory.SKIN
 
@@ -204,7 +205,22 @@ async function handleZippedModelFiles<T extends Content>(
         MAX_SKIN_FILE_SIZE,
         FileType.SKIN
       )
-    } else if (!isSkin && contentsSize > MAX_WEARABLE_FILE_SIZE) {
+    } else if (
+      !isSkin &&
+      isSmartWearable &&
+      contentsSize > MAX_SMART_WEARABLE_FILE_SIZE
+    ) {
+      throw new FileTooBigError(
+        fileName,
+        contentsSize,
+        MAX_SMART_WEARABLE_FILE_SIZE,
+        FileType.SMART_WEARABLE
+      )
+    } else if (
+      !isSkin &&
+      !isSmartWearable &&
+      contentsSize > MAX_WEARABLE_FILE_SIZE
+    ) {
       throw new FileTooBigError(
         fileName,
         contentsSize,

--- a/src/files/types.ts
+++ b/src/files/types.ts
@@ -66,5 +66,6 @@ export enum FileType {
   WEARABLE = 'wearable',
   SKIN = 'skin',
   THUMBNAIL = 'thumbnail',
-  EMOTE = 'emote'
+  EMOTE = 'emote',
+  SMART_WEARABLE = 'smart-wearable'
 }


### PR DESCRIPTION
This PR updates the logic to handle the maximum file size for smart wearables. 

As it's a unique kind of wearable with multiple files inside a .zip, use the max file size for wearables (2MB + 1MB for thumbnail and image) as much as possible.