### PR TITLE
fix: Increases the model sizes to includes the thumbnail size

### DIFF
--- a/src/files/constants.ts
+++ b/src/files/constants.ts
@@ -1,8 +1,9 @@
 /** @deprecated please use MAX_THUMBNAILS_FILE_SIZE | MAX_WEARABLE_FILE_SIZE | MAX_SKIN_FILE_SIZE | MAX_EMOTE_FILE_SIZE instead */
 export const MAX_FILE_SIZE = 2 * 1024 * 1024 // 2MB
 export const MAX_THUMBNAIL_FILE_SIZE = 1024 * 1024 // 1MB
-export const MAX_WEARABLE_FILE_SIZE = 2 * 1024 * 1024 // 2MB
-export const MAX_EMOTE_FILE_SIZE = 2 * 1024 * 1024 // 2MB
+/* Use the model size + thumbnail size until there's a clear definition of how the catalyst will handle the thumbnail size calculation */
+export const MAX_WEARABLE_FILE_SIZE = 3 * 1024 * 1024 // 3MB
+export const MAX_EMOTE_FILE_SIZE = 3 * 1024 * 1024 // 3MB
 export const MAX_SKIN_FILE_SIZE = 8 * 1024 * 1024 // 8MB
 export const MAX_SMART_WEARABLE_FILE_SIZE = 3 * 1024 * 1024 // 3MB
 export const WEARABLE_MANIFEST = 'wearable.json'


### PR DESCRIPTION
This PR increases the model sizes to include the thumbnail size until there's a clear definition of how the catalyst will calculate the thumbnail size.

