### PR TITLE
fix: treat facial-expressions PNGs as auxiliary in main-model detection

### DIFF
--- a/src/files/files.spec.ts
+++ b/src/files/files.spec.ts
@@ -992,6 +992,74 @@ describe('when loading an item file', () => {
           })
         })
       })
+
+      describe('and it contains a base PNG alongside facial expressions auxiliaries', () => {
+        const baseImage = 'red_eyes.png'
+        const maskImage = 'red_eyes_mask.png'
+        const expressionsImage = 'red_eyes_expressions.png'
+        const expressionsMaskImage = 'red_eyes_expressions_mask.png'
+        let expressionsContent: Uint8Array
+        let expressionsMaskContent: Uint8Array
+        let maskContent: Uint8Array
+
+        beforeEach(async () => {
+          maskContent = new Uint8Array([10, 11])
+          expressionsContent = new Uint8Array([20, 21])
+          expressionsMaskContent = new Uint8Array([30, 31])
+          zipFile.file(baseImage, modelContent)
+          zipFile.file(maskImage, maskContent)
+          zipFile.file(expressionsImage, expressionsContent)
+          zipFile.file(expressionsMaskImage, expressionsMaskContent)
+          zipFileContent = await zipFile.generateAsync({ type: 'uint8array' })
+        })
+
+        it('should pick the base PNG as the main model and keep every auxiliary file in the contents', () => {
+          return expect(loadFile(fileName, zipFileContent)).resolves.toEqual({
+            content: {
+              [baseImage]: modelContent,
+              [maskImage]: maskContent,
+              [expressionsImage]: expressionsContent,
+              [expressionsMaskImage]: expressionsMaskContent,
+              [THUMBNAIL_PATH]: thumbnailContent
+            },
+            mainModel: baseImage
+          })
+        })
+      })
+
+      describe('and it contains only an _expressions.png file without its base PNG', () => {
+        const expressionsImage = 'red_eyes_expressions.png'
+        let expressionsContent: Uint8Array
+
+        beforeEach(async () => {
+          expressionsContent = new Uint8Array([20, 21])
+          zipFile.file(expressionsImage, expressionsContent)
+          zipFileContent = await zipFile.generateAsync({ type: 'uint8array' })
+        })
+
+        it('should treat the expressions file as auxiliary and throw a model-not-found error', () => {
+          return expect(loadFile(fileName, zipFileContent)).rejects.toThrow(
+            new ModelFileNotFoundError()
+          )
+        })
+      })
+
+      describe('and it contains only an _expressions_mask.png file without its base PNG', () => {
+        const expressionsMaskImage = 'red_eyes_expressions_mask.png'
+        let expressionsMaskContent: Uint8Array
+
+        beforeEach(async () => {
+          expressionsMaskContent = new Uint8Array([30, 31])
+          zipFile.file(expressionsMaskImage, expressionsMaskContent)
+          zipFileContent = await zipFile.generateAsync({ type: 'uint8array' })
+        })
+
+        it('should treat the expressions mask as auxiliary and throw a model-not-found error', () => {
+          return expect(loadFile(fileName, zipFileContent)).rejects.toThrow(
+            new ModelFileNotFoundError()
+          )
+        })
+      })
     })
   })
 })

--- a/src/files/files.spec.ts
+++ b/src/files/files.spec.ts
@@ -1060,6 +1060,42 @@ describe('when loading an item file', () => {
           )
         })
       })
+
+      describe('and it contains only a _mask.png file without its base PNG', () => {
+        const maskImage = 'red_eyes_mask.png'
+        let maskContent: Uint8Array
+
+        beforeEach(async () => {
+          maskContent = new Uint8Array([10, 11])
+          zipFile.file(maskImage, maskContent)
+          zipFileContent = await zipFile.generateAsync({ type: 'uint8array' })
+        })
+
+        it('should treat the mask file as auxiliary and throw a model-not-found error', () => {
+          return expect(loadFile(fileName, zipFileContent)).rejects.toThrow(
+            new ModelFileNotFoundError()
+          )
+        })
+      })
+
+      describe('and it contains a PNG whose name has `_mask` somewhere other than as the suffix', () => {
+        const mainImage = 'red_mask_eyes.png'
+
+        beforeEach(async () => {
+          zipFile.file(mainImage, modelContent)
+          zipFileContent = await zipFile.generateAsync({ type: 'uint8array' })
+        })
+
+        it('should treat the file as a main model, since only filenames ending in `_mask.png` are auxiliary', () => {
+          return expect(loadFile(fileName, zipFileContent)).resolves.toEqual({
+            content: {
+              [mainImage]: modelContent,
+              [THUMBNAIL_PATH]: thumbnailContent
+            },
+            mainModel: mainImage
+          })
+        })
+      })
     })
   })
 })

--- a/src/files/files.ts
+++ b/src/files/files.ts
@@ -90,12 +90,13 @@ function isModelFile(fileName: string) {
 
 function isModelPath(fileName: string) {
   fileName = fileName.toLowerCase()
-  // we ignore PNG files that end with "_mask", since those are auxiliary
-  const isMask = fileName.includes('_mask')
+  // PNG files for masks and facial expressions are auxiliary; only the base PNG is the main file
+  const isAuxiliary =
+    fileName.endsWith('_mask.png') || fileName.endsWith('_expressions.png')
   return (
     isModelFile(fileName) ||
     (fileName.indexOf(THUMBNAIL_PATH) === -1 &&
-      !isMask &&
+      !isAuxiliary &&
       isImageFile(fileName))
   )
 }


### PR DESCRIPTION
## Why

The builder's facial-expressions support ([builder PR #3404](https://github.com/decentraland/builder/pull/3404)) lets creators ship `*_expressions.png` and `*_expressions_mask.png` alongside the base PNG for image-based wearables (`eyes`, `eyebrows`, `mouth`). For that to work end-to-end, the upload pipeline needs a consistent definition of which PNGs are "auxiliary" (mask/expressions) versus the main model file.

`isModelPath` in this library — used inside `handleZippedModelFiles` when no `wearable.json` is present — only excluded filenames containing `_mask`. That means:

1. A zip containing `red_eyes.png` + `red_eyes_expressions.png` and no `wearable.json` could non-deterministically pick `red_eyes_expressions.png` as the main model (depending on zip iteration order), because `_expressions.png` didn't match the auxiliary heuristic.
2. A zip containing **only** an `_expressions.png` would happily resolve as if it were a valid wearable, returning `mainModel: red_eyes_expressions.png` instead of throwing `ModelFileNotFoundError`. The base PNG is supposed to be required.

The fix aligns this library's main-model detection with the same convention enforced by the builder.

## How

`isModelPath` now treats a PNG as auxiliary when its filename ends with `_mask.png` or `_expressions.png`. The `_mask.png` suffix also covers `_expressions_mask.png` by construction, so two `endsWith` checks are enough. Only the base PNG (no auxiliary suffix, not the thumbnail) qualifies as a main model candidate.

```ts
const isAuxiliary =
  fileName.endsWith('_mask.png') || fileName.endsWith('_expressions.png')
```

Notable behavioral change beyond the new suffixes: the check switched from `fileName.includes('_mask')` (substring) to `fileName.endsWith('_mask.png')` (suffix). A pathological filename like `red_mask_eyes.png` used to be excluded as auxiliary; it now qualifies as a main candidate. This is the more precise rule and matches what creators document.

## Test plan

- [x] Existing 31 tests in `files.spec.ts` still pass (no regressions in size limits, manifest handling, scene/emote/builder configs, or single-model uploads).
- [x] New coverage in `files.spec.ts`:
  - Zip with base PNG + `_mask.png` + `_expressions.png` + `_expressions_mask.png` → base PNG is picked as `mainModel`, all four files appear in `content`.
  - Zip with **only** `_expressions.png` (no base) → throws `ModelFileNotFoundError`.
  - Zip with **only** `_expressions_mask.png` (no base) → throws `ModelFileNotFoundError`.
- [x] Full suite (`npx jest`): 184 tests pass.